### PR TITLE
fix: spelling error in remove address dialog

### DIFF
--- a/core/src/main/java/dev/jdtech/jellyfin/dialogs/DeleteServerAddressDialog.kt
+++ b/core/src/main/java/dev/jdtech/jellyfin/dialogs/DeleteServerAddressDialog.kt
@@ -17,7 +17,7 @@ class DeleteServerAddressDialog(
         return activity?.let {
             val builder = MaterialAlertDialogBuilder(it)
             builder.setTitle("Remove server address")
-                .setMessage("Are you sure you want to remove the server addres? ${address.address}")
+                .setMessage("Are you sure you want to remove the server address? ${address.address}")
                 .setPositiveButton(getString(R.string.remove)) { _, _ ->
                     viewModel.deleteAddress(address)
                 }


### PR DESCRIPTION
Not tested. Saw it while using the app and it looked like an easy fix.